### PR TITLE
Improve intro and difficulty

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,20 +1,31 @@
 let game;
 let character, cursors,
     score = 0,
-    playerSpeed = 400,
+    playerSpeed = 650,
     obstacleSpeed = 200;
-let scoreText, obstacles, gameOverFlag = false, playerName = '', charVariant = 1;
+let scoreText, speedText, obstacles, gameOverFlag = false, playerName = '', charVariant = 1;
 let music;
+let background;
 const BASE_SPEED = 200;
-const MAX_OBSTACLES = 3, SPAWN_INTERVAL = 1500;
+let MAX_OBSTACLES = 3;
+const SPAWN_INTERVAL = 1500;
+let texture = 'mm';
+let spawnTimer = 0;
 
 function init() {
   const overlay = document.getElementById('overlay');
+  const splash = document.getElementById('splash');
   const nameInput = document.getElementById('nameInput');
   const startBtn = document.getElementById('startBtn');
   const hsDiv = document.getElementById('hs');
+  const hsList = document.getElementById('overlayHSList');
 
-  loadHighscores(hsDiv);
+  setTimeout(() => {
+    if (splash) splash.style.display = 'none';
+    if (overlay) overlay.style.display = 'flex';
+  }, 3000);
+
+  loadHighscores(hsDiv, hsList);
 
   startBtn.onclick = () => {
     const n = nameInput.value.trim();
@@ -27,30 +38,47 @@ function init() {
     else if (pg === 'm' && ug === 'f') charVariant = 3;
     else charVariant = 4;
 
+    const charMap = { 1: 'mm', 2: 'fm', 3: 'mf', 4: 'ff' };
+    texture = charMap[charVariant] || 'mm';
+
     playerName = n;
     overlay.style.display = 'none';
     startGame();
   };
 }
 
-async function loadHighscores(target) {
+async function loadHighscores(target, listEl) {
   try {
-    let r = await fetch('highscore.php', { cache: 'no-store' });
+    const r = await fetch('highscore.php', { cache: 'no-store' });
     if (!r.ok) throw new Error('php failed');
-    let data = await r.json();
-    target.innerText = '🏆 Highscore:\n' +
-      data.map((e, i) => `${i + 1}. ${e.name} – ${e.score}`).join('\n');
+    const data = await r.json();
+    renderScores(data, target, listEl);
   } catch (e) {
-    console.warn('highscore.php failed, trying scores.json', e);
     try {
       const r = await fetch('scores.json', { cache: 'no-store' });
       const data = await r.json();
-      target.innerText = '🏆 Highscore:\n' +
-        data.map((e, i) => `${i + 1}. ${e.name} – ${e.score}`).join('\n');
+      renderScores(data, target, listEl);
     } catch (err) {
-      console.error('Could not load highscores', err);
+      console.error('Highscore-feil:', err);
       target.innerText = 'Kunne ikke laste highscore.';
+      if (listEl) listEl.innerHTML = '<li>Feil ved lasting</li>';
     }
+  }
+}
+
+function renderScores(data, target, listEl) {
+  const sorted = data.sort((a, b) => b.score - a.score);
+  const top10 = sorted.slice(0, 10);
+  target.innerText = '🏆 Highscore:\n' +
+    top10.map((e, i) => `${i + 1}. ${e.name} – ${e.score}`).join('\n');
+
+  if (listEl) {
+    listEl.innerHTML = '';
+    sorted.slice(0, 5).forEach((e, i) => {
+      const li = document.createElement('li');
+      li.textContent = `${i + 1}. ${e.name} – ${e.score}`;
+      listEl.appendChild(li);
+    });
   }
 }
 
@@ -62,12 +90,11 @@ if (document.readyState === 'complete' || document.readyState === 'interactive')
 
 function startGame() {
   score = 0;
-  playerSpeed = 400;
+  playerSpeed = 650;
   obstacleSpeed = BASE_SPEED;
   gameOverFlag = false;
-  if (music) {
-    music.stop();
-  }
+  spawnTimer = 0;
+  if (music) music.stop();
 
   const config = {
     type: Phaser.AUTO,
@@ -89,19 +116,24 @@ function startGame() {
 }
 
 function preload() {
-  const variants = ['mm', 'fm', 'mf', 'ff'];
-  variants.forEach((name, idx) => {
-    const i = idx + 1;
-    this.load.image(`right_${i}`, `assets/${name}.png`);
-    this.load.image(`left_${i}`, `assets/${name}.png`);
-  });
-  this.load.image('obst_barnevogn', 'assets/obst_barnevogn.png');
-  this.load.image('obst_hundemann', 'assets/obst_hundemann.png');
-  this.load.image('obst_skater', 'assets/obst_skater.png');
-  this.load.audio('bgmusic', 'assets/b22soundscape.ogg');
+  this.load.image('bg', 'https://terapisomvirker.no/b22/assets/background_grass.png');
+  this.load.image('mm', 'assets/mm.png?v=2');
+  this.load.image('mf', 'assets/mf.png?v=2');
+  this.load.image('fm', 'assets/fm.png?v=2');
+  this.load.image('ff', 'assets/ff.png?v=2');
+
+  this.load.image('obst_barnevogn', 'assets/obst_barnevogn.png?v=2');
+  this.load.image('obst_hundemann', 'assets/obst_hundemann.png?v=2');
+  this.load.image('obst_skater', 'assets/obst_skater.png?v=2');
+
+  this.load.audio('bgmusic', 'assets/B22soundscape.ogg?v=2');
 }
 
 function create() {
+  background = this.add.tileSprite(0, 0, this.cameras.main.width, this.cameras.main.height, 'bg');
+  background.setOrigin(0, 0);
+  background.setDepth(0);
+
   const centerX = this.cameras.main.width / 2;
   const centerY = this.cameras.main.height * 0.8;
 
@@ -109,7 +141,7 @@ function create() {
   music.play();
   music.setRate(1);
 
-  character = this.physics.add.sprite(centerX, centerY, `right_${charVariant}`);
+  character = this.physics.add.sprite(centerX, centerY, texture);
   character.setCollideWorldBounds(true);
 
   cursors = this.input.keyboard.createCursorKeys();
@@ -119,57 +151,77 @@ function create() {
   });
 
   obstacles = this.physics.add.group();
-  this.time.addEvent({
-    delay: SPAWN_INTERVAL,
-    callback: spawnObstacle,
-    callbackScope: this,
-    loop: true
-  });
 
   scoreText = this.add.text(10, 10, 'Poeng: 0', {
     font: '24px sans-serif',
     fill: '#000'
+  }).setDepth(10);
+
+  speedText = this.add.text(10, this.cameras.main.height - 30, 'Fart: 0', {
+    font: '20px sans-serif',
+    fill: '#00aa00'
   }).setDepth(10);
 }
 
 function spawnObstacle() {
   if (gameOverFlag || obstacles.getChildren().length >= MAX_OBSTACLES) return;
 
-  const x = Phaser.Math.Between(50, game.config.width - 50);
+  const screenWidth = game.config.width;
+  const x = Phaser.Math.Between(screenWidth * 0.2, screenWidth * 0.8);
+
   const types = ['obst_barnevogn', 'obst_hundemann', 'obst_skater'];
   const type = Phaser.Utils.Array.GetRandom(types);
   const o = obstacles.create(x, -100, type);
   o.setData('type', type);
+
   const scaleMap = {
-    obst_hundemann: 0.25,
-    obst_barnevogn: 0.4,
-    obst_skater: 0.4
+    obst_hundemann: 1.0,
+    obst_barnevogn: 1.0,
+    obst_skater: 1.0
   };
-  o.setScale(scaleMap[type] || 0.4);
+  o.setScale(scaleMap[type] || 1.0);
   o.setVelocityY(obstacleSpeed);
   o.setDepth(1);
 }
 
 function update(time, delta) {
+  if (!this.obstacleTimer) this.obstacleTimer = 0;
+  this.obstacleTimer += delta;
+  if (this.obstacleTimer > 15000 && MAX_OBSTACLES < 7) {
+    MAX_OBSTACLES++;
+    this.obstacleTimer = 0;
+  }
+
+  spawnTimer += delta;
+  const spawnInterval = Math.max(400, SPAWN_INTERVAL * (BASE_SPEED / obstacleSpeed));
+  if (spawnTimer > spawnInterval) {
+    spawnObstacle();
+    spawnTimer = 0;
+  }
+
   if (gameOverFlag || !character) return;
+
+  if (background) {
+    background.tilePositionY -= obstacleSpeed * delta / 1000;
+  }
 
   const left = cursors.left.isDown || (this.input.activePointer.isDown && this.input.activePointer.x < game.config.width / 2);
   const right = cursors.right.isDown || (this.input.activePointer.isDown && this.input.activePointer.x > game.config.width / 2);
 
+  const moveAmount = playerSpeed * delta / 1000;
+  const minX = game.config.width * 0.2 + 40;
+  const maxX = game.config.width * 0.8 - 40;
+
   if (left) {
-    character.x -= playerSpeed * delta / 1000;
-    character.setTexture(`left_${charVariant}`);
+    character.x = Math.max(minX, character.x - moveAmount);
   } else if (right) {
-    character.x += playerSpeed * delta / 1000;
-    character.setTexture(`right_${charVariant}`);
-  } else {
-    character.setTexture(`right_${charVariant}`);
+    character.x = Math.min(maxX, character.x + moveAmount);
   }
 
   const obs = obstacles.getChildren();
   for (let i = obs.length - 1; i >= 0; i--) {
     const o = obs[i];
-    if (!o || !o.active || typeof o.getBounds !== 'function') continue;
+    if (!o || !o.active || !o.body || typeof o.getBounds !== 'function') continue;
 
     if (o.y > game.config.height + 50) {
       obstacles.remove(o, true, true);
@@ -189,20 +241,26 @@ function update(time, delta) {
     }
   }
 
+  obstacleSpeed = Math.min(obstacleSpeed + delta * 0.01, 600);
+
+  const rate = Math.min(1 + (obstacleSpeed - BASE_SPEED) / 500, 2.0);
+  if (music) music.setRate(rate);
+
+  if (speedText) {
+    speedText.setText(`Fart: ${Math.floor(obstacleSpeed)}`);
+    if (obstacleSpeed < 300) speedText.setColor('#00aa00');
+    else if (obstacleSpeed < 450) speedText.setColor('#ffaa00');
+    else speedText.setColor('#ff0000');
+  }
+
   score += delta / 1000;
   scoreText.setText(`Poeng: ${Math.floor(score)}`);
-  obstacleSpeed += delta / 10000;
-  if (music) {
-    music.setRate(obstacleSpeed / BASE_SPEED);
-  }
 }
 
 function gameOver(scene) {
   gameOverFlag = true;
   scene.physics.pause();
-  if (music) {
-    music.stop();
-  }
+  if (music) music.stop();
 
   scene.add.rectangle(
     scene.cameras.main.centerX,
@@ -224,25 +282,35 @@ function gameOver(scene) {
     fill: '#fff'
   }).setOrigin(0.5).setDepth(10);
 
-  const btn = scene.add.text(scene.cameras.main.width / 2, scene.cameras.main.height / 2 + 60, 'Send highscore', {
+  const btn = scene.add.text(scene.cameras.main.width / 2, scene.cameras.main.height / 2 + 60, 'Gratulerer! Vil du lagre din score?', {
     font: '24px sans-serif',
     fill: '#0f0'
   }).setOrigin(0.5).setDepth(10).setInteractive();
 
   btn.on('pointerdown', () => submitScore(Math.floor(score)));
+
+  const retryBtn = scene.add.text(scene.cameras.main.width / 2, scene.cameras.main.height / 2 + 110, 'Try Again?', {
+    font: '28px Courier',
+    fill: '#00ffff',
+    backgroundColor: '#000',
+    padding: { x: 10, y: 5 }
+  }).setOrigin(0.5).setDepth(10).setInteractive();
+
+  retryBtn.on('pointerdown', () => {
+    const overlay = document.getElementById('overlay');
+    if (overlay) overlay.style.display = 'flex';
+    game.destroy(true);
+  });
 }
 
-async function submitScore(val) {
-  try {
-    const r = await fetch('highscore.php', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: playerName, score: val })
-    });
-    const res = await r.json();
-    alert(res.success ? 'Highscore lagret!' : 'Kunne ikke lagre.');
-    window.location.reload();
-  } catch (e) {
-    alert('Feilet ved sending av highscore.');
-  }
+function submitScore(val) {
+  fetch('highscore.php', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: playerName, score: val })
+  })
+    .then(r => r.json())
+    .then(res => alert(res.success ? 'Highscore lagret!' : 'Kunne ikke lagre.'))
+    .then(() => window.location.reload())
+    .catch(() => alert('Feilet ved sending av highscore.'));
 }

--- a/index.html
+++ b/index.html
@@ -5,21 +5,24 @@
   <title>Miljøterapeuttur</title>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <style>
-    body, html { margin:0; padding:0; overflow:hidden; background:#a0d8f1; }
-    #hs { position:absolute; top:5px; right:5px; background:#fff8; padding:10px; border-radius:4px; font-family:sans-serif; }
-    #overlay { position:absolute; left:0; top:0; width:100%; height:100%; background:#000c; color:#fff; display:flex; align-items:center; justify-content:center; flex-direction:column; font-family:sans-serif; font-size:20px; text-align:center; }
-    #overlay img { max-width:80%; height:auto; margin-bottom:20px; }
+    body, html { margin:0; padding:0; overflow:hidden; background:#000; }
+    #hs { position:absolute; top:5px; right:5px; background:#111; color:#0f0; padding:10px; border-radius:4px; font-family:'Courier New', monospace; }
+    #splash { position:absolute; left:0; top:0; width:100%; height:100%; display:flex; align-items:center; justify-content:center; background:#000; }
+    #splash img { max-width:80%; height:auto; }
+    #overlay { position:absolute; left:0; top:0; width:100%; height:100%; background:#000; color:#0f0; display:none; align-items:center; justify-content:center; flex-direction:column; font-family:'Courier New', monospace; font-size:20px; text-align:center; }
     .opt-group { margin:10px 0; }
-    button { font-size:18px; padding:10px 20px; margin-top:10px; }
-    input { font-size:18px; padding:5px; }
+    button { font-size:18px; padding:10px 20px; margin-top:10px; font-family:'Courier New', monospace; }
+    input { font-size:18px; padding:5px; font-family:'Courier New', monospace; }
+    #overlayHSList { list-style:none; padding:10px; margin-top:20px; border:2px solid #0f0; background:#000; width:220px; }
+    #overlayHSList li { text-align:left; }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.min.js"></script>
 </head>
 <body>
 
 <div id="hs">Highscore lastes...</div>
+<div id="splash"><img src="assets/splash.png" alt="Splash"/></div>
 <div id="overlay">
-  <img src="assets/splash.png" alt="splash"/>
   <div class="opt-group">
     Terapeut:
     <label><input type="radio" name="playerGender" value="m" checked> M</label>
@@ -33,6 +36,7 @@
   <div>Skriv inn kallenavn:</div>
   <input id="nameInput" maxlength="12" placeholder="Navn"/>
   <button id="startBtn">Start spillet</button>
+  <ul id="overlayHSList"></ul>
 </div>
 
 <script src="game.js"></script>


### PR DESCRIPTION
## Summary
- add separate splash screen and retro start overlay
- load remote background asset
- spawn obstacles faster as speed increases
- style highscore list with retro look

## Testing
- `pip install Pillow`


------
https://chatgpt.com/codex/tasks/task_e_6851409e672483329e6966f46622a3ce